### PR TITLE
Add "load all variables" cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,14 @@ Completed setting variables on Gitlab CI.
 
 Download all variable key/values to a properties file.
 
-Run the following command from the directory that contains the properties file, eg.
+Run the following command to save the properties file to `gitlab.env.yml` in the current directory or
+optionally specify an alternative destination, eg.
 
 - `gitlab-token` is your Gitlab personal access token
 - `gitlab-project-url` is your project url on gitlab, e.g. https://gitlab.com/gitlab-org/gitlab-ce
 
 ```sh
-$ glci lav --token <gitlab-token> --url <gitlab-project-url>
+$ glci lav --token <gitlab-token> --url <gitlab-project-url> --out gitlab.env.yml
 Downloaded variables from Gitlab CI.
 Saved variables to gitlab.env.yml
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ npm install -g gitlab-ci-variables-setter-cli
 
 ## Usage
 
-### One variable (`glci sv`)
+### Save one variable (`glci sv`)
 
 Run the following command, where:
 
@@ -33,7 +33,7 @@ Set <key> = <value> for gitlab-org/gitlab-ce.
 Completed setting variable on Gitlab CI.
 ```
 
-### Several variables (`glci sav`)
+### Save several variables (`glci sav`)
 
 Put all required variable key/values on a properties file named `gitlab.env.yml`, e.g:
 
@@ -57,6 +57,21 @@ $ glci sav --token <gitlab-token> --url <gitlab-project-url>
 Set AWS_CREDENTIALS = <value> for gitlab-org/gitlab-ce.
 Set NPM_INSTALL_TOKEN = <value> for gitlab-org/gitlab-ce.
 Completed setting variables on Gitlab CI.
+```
+
+### Load several variables (`glci lav`)
+
+Download all variable key/values to a properties file.
+
+Run the following command from the directory that contains the properties file, eg.
+
+- `gitlab-token` is your Gitlab personal access token
+- `gitlab-project-url` is your project url on gitlab, e.g. https://gitlab.com/gitlab-org/gitlab-ce
+
+```sh
+$ glci lav --token <gitlab-token> --url <gitlab-project-url>
+Downloaded variables from Gitlab CI.
+Saved variables to gitlab.env.yml
 ```
 
 #### For all usages

--- a/src/glci-lav.js
+++ b/src/glci-lav.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+import program from 'commander';
+import { getConf } from './lib/utils';
+import { savePropertiesFile } from './lib/properties-file';
+import gitlabCI from './lib/gitlab-ci';
+
+async function execute() {
+  const conf = await getConf();
+
+  const handler = gitlabCI(conf.url, conf.token);
+  const resp = await handler.listVariables();
+
+  console.log('Downloaded variables from Gitlab CI.');
+
+  savePropertiesFile(`${process.cwd()}/conf.out`, resp);
+
+  console.log(`Saved variables to ${conf.out}`);
+
+  return resp;
+}
+
+program
+  .description('Read all key/value pairs from Gitlab API and saves them to the specified .yml file')
+  .option(
+    '--url <url>',
+    'Your Gitlab project URL, e.g. https://gitlab.com/gitlab-org/gitlab-ce',
+  )
+  .option(
+    '--token <token>',
+    'Your Gitlab token.',
+  )
+  .option(
+    '--out <out>',
+    'The location to save CI values to.',
+    'gitlab.env.yml',
+  )
+  .parse(process.argv);
+
+execute(program);

--- a/src/glci.js
+++ b/src/glci.js
@@ -7,8 +7,8 @@ program
   .version(npmPackage.version)
   .command('sv', 'set a variable')
   .command('sav', 'set all variables')
+  .command('lav', 'load all variables')
   .parse(process.argv);
-
 
 if (!process.argv.slice(1).length) {
   program.outputHelp();

--- a/src/lib/properties-file.js
+++ b/src/lib/properties-file.js
@@ -9,7 +9,7 @@ import yaml from 'js-yaml';
  *
  * @return {Object} properties
  */
-export default function loadPropertiesFile(path) {
+export function loadPropertiesFile(path) {
   let doc;
   try {
     const contents = fs.readFileSync(path, 'utf8');

--- a/src/lib/properties-file.js
+++ b/src/lib/properties-file.js
@@ -20,3 +20,25 @@ export default function loadPropertiesFile(path) {
 
   return doc;
 }
+
+/**
+ * Save properties object into properties file
+ * A property is a key/value pair.
+ *
+ * @param path
+ * @param obj
+ *
+ */
+export function savePropertiesFile(path, obj) {
+  const contents = {};
+  obj.forEach((envVar) => {
+    contents[envVar.key] = envVar.value;
+  });
+
+  try {
+    const string = yaml.safeDump(contents);
+    fs.writeFileSync(path, string, 'utf8');
+  } catch (error) {
+    console.log(error);
+  }
+}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -2,7 +2,7 @@ import rc from 'rc';
 import fs from 'fs';
 import gitRemoteOriginUrl from 'git-remote-origin-url';
 import getUrlFromGitRemote from './git';
-import loadPropertiesFile from './properties-file';
+import { loadPropertiesFile } from './properties-file';
 
 const gitlabEnvFileName = 'gitlab.env.yml';
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -34,6 +34,10 @@ async function getConf() {
     }
   }
 
+  if (!conf.out) {
+    conf.out = gitlabEnvFileName;
+  }
+
   if (errors.length > 0) {
     console.error(errors.join('\n'));
     process.exit(1);

--- a/test/lib/properties-file.test.js
+++ b/test/lib/properties-file.test.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import loadPropertiesFile from '../../src/lib/properties-file';
+import { loadPropertiesFile, savePropertiesFile } from '../../src/lib/properties-file';
+import { readFileSync, unlinkSync } from 'fs';
 
 const cwd = process.cwd();
 
@@ -12,6 +13,31 @@ describe('properties-file-handler', () => {
       expect(properties.BIBLIOTECA).to.equal('docs');
       expect(properties.DEPLOYMENT_REGION).to.equal('us-east-1');
       expect(properties.NPM_INSTALL_TOKEN).to.equal(123456789);
+    });
+  });
+
+  context('savePropertiesFile', () => {
+    it('saves properties object into properties file', () => {
+      const path = `${cwd}/test/fixtures/test-save.yml`;
+      savePropertiesFile(path, [
+        {
+          key: 'TEST_KEY',
+          value: 'hello',
+          protected: false,
+        },
+        {
+          key: 'TOKEN',
+          value: 'jkdsjkldfsjkl',
+          protected: false,
+        }
+      ]);
+
+      const result = readFileSync(path, 'utf8');
+      expect(result).to.equal(`TEST_KEY: hello
+TOKEN: jkdsjkldfsjkl
+`);
+
+      unlinkSync(path);
     });
   });
 });


### PR DESCRIPTION
Adds a `load all variables (lav)` command, allowing easy migration between repo CIs. eg.

```
glci lav --token <gitlab-token> --url <gitlab-project-url-existing>
glci sav --token <gitlab-token> --url <gitlab-project-url-fork>
```