### PR TITLE
feat: add new options (masked, protected, raw, scope) and handle HTTP errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin
 gitlab.env.yml
 .nyc_output
 .gitlabrc
+.idea

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   ],
   "scripts": {
     "lint": "$(npm bin)/eslint src",
-    "test": "NODE_ENV=test $(npm bin)/mocha --recursive --compilers js:babel-core/register test",
-    "test:coverage": "$(npm bin)/nyc --check-coverage --lines 90 --reporter=text --reporter=text-summary npm test",
-    "build": "rm -Rf bin && $(npm bin)/babel src --out-dir bin --source-maps inline",
+    "test": "NODE_ENV=test ./node_modules/.bin/mocha --recursive --compilers js:babel-core/register test",
+    "test:coverage": "./node_modules/.bin/nyc --check-coverage --lines 90 --reporter=text --reporter=text-summary npm test",
+    "build": "rm -Rf bin && ./node_modules/.bin/babel src --out-dir bin --source-maps inline",
     "deploy": "npm run build && npm link",
     "preversion": "npm run build && npm run lint && npm run test"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "$(npm bin)/eslint src",
     "test": "NODE_ENV=test ./node_modules/.bin/mocha --recursive --compilers js:babel-core/register test",
     "test:coverage": "./node_modules/.bin/nyc --check-coverage --lines 90 --reporter=text --reporter=text-summary npm test",
-    "build": "rm -Rf bin && ./node_modules/.bin/babel src --out-dir bin --source-maps inline",
+    "build": "rm -Rf bin && ./node_modules/.bin/babel src --out-dir bin --source-maps inline && chmod +x ./bin/*.js",
     "deploy": "npm run build && npm link",
     "preversion": "npm run build && npm run lint && npm run test"
   },

--- a/src/glci-set.js
+++ b/src/glci-set.js
@@ -19,15 +19,20 @@ async function execute(cmd) {
 
   const keyExists = existingKeys.includes(conf.key);
 
+  const isProtected = Boolean(cmd.protected);
+  const masked = Boolean(cmd.masked);
+  const raw = Boolean(cmd.raw);
+  const scope = cmd.environmentScope !== undefined ? cmd.environmentScope : '*';
+
   if (keyExists && cmd.doNotForce) {
     console.log(`Skipping ${conf.key}, already set.`);
     return undefined;
   }
 
   if (keyExists) {
-    resp = await handler.updateVariable(conf.key, conf.value);
+    resp = await handler.updateVariable(conf.key, conf.value, isProtected, masked, raw, scope);
   } else {
-    resp = await handler.createVariable(conf.key, conf.value);
+    resp = await handler.createVariable(conf.key, conf.value, isProtected, masked, raw, scope);
   }
 
   console.log('Completed setting variable on Gitlab CI.');
@@ -53,8 +58,20 @@ program
     'Your Gitlab CI value',
   )
   .option(
-    '--do-not-force',
-    'Ignore variable if it already exists on gitlab CI. By default variable is overridden',
+    '--protected',
+    'Set the variable as protected. By default it is not protected',
+  )
+  .option(
+    '--masked',
+    'Set the variable as masked. By default it is not masked',
+  )
+  .option(
+    '--raw',
+    'Set the variable as raw. By default it is not raw',
+  )
+  .option(
+    '--environment-scope <environment-scope>',
+    'Set the environment scope. By default it is set to *',
   )
   .parse(process.argv);
 

--- a/src/glci-setAll.js
+++ b/src/glci-setAll.js
@@ -8,8 +8,13 @@ async function execute(cmd) {
   const conf = await getConf();
 
   const properties = getProperties();
+  const forceUpdate = !cmd.doNotForce;
+  const isProtected = Boolean(cmd.protected);
+  const masked = Boolean(cmd.masked);
+  const raw = Boolean(cmd.raw);
+  const scope = cmd.environmentScope !== undefined ? cmd.environmentScope : '*';
   const handler = gitlabCI(conf.url, conf.token);
-  const resp = await handler.setVariables(properties, !cmd.doNotForce);
+  const resp = await handler.setVariables(properties, forceUpdate, isProtected, masked, raw, scope);
 
   console.log('Completed setting variables on Gitlab CI.');
   return resp;
@@ -28,6 +33,22 @@ program
   .option(
     '--do-not-force',
     'Ignore variables if they already exist on gitlab CI. By default all variables are overridden',
+  )
+  .option(
+    '--protected',
+    'Set the variable as protected. By default it is not protected',
+  )
+  .option(
+    '--masked',
+    'Set the variable as masked. By default it is not masked',
+  )
+  .option(
+    '--raw',
+    'Set the variable as raw. By default it is not raw',
+  )
+  .option(
+    '--environment-scope <environmentScope>',
+    'Set the environment scope. By default it is set to *',
   )
   .parse(process.argv);
 

--- a/src/lib/gitlab-ci.js
+++ b/src/lib/gitlab-ci.js
@@ -118,9 +118,19 @@ export default function gitlabCI(url, token) {
    * @return {Promise<Array>} array of variable objects
    */
   async function listVariables() {
-    const response = await axios.get(`${apiUrl}?${tokenQueryString}&${perPageQueryString}`);
+    let response = await axios.get(`${apiUrl}?${tokenQueryString}&${perPageQueryString}&page=1`);
 
-    return response.data;
+    const nbPages = response.headers['x-total-pages'] !== undefined ? response.headers['x-total-pages'] : 1;
+
+    let data = response.data;
+
+    for (let page = 2; page <= nbPages; page += 1) {
+      /* eslint-disable no-await-in-loop */
+      response = await axios.get(`${apiUrl}?${tokenQueryString}&${perPageQueryString}&page=${page}`);
+      data = [...data, ...response.data];
+    }
+
+    return data;
   }
 
   /**


### PR DESCRIPTION
Thanks for this!

I needed to add support for the `masked` to insert secrets but it was not supported.

I added other options as well ([see reference](https://docs.gitlab.com/ee/api/project_level_variables.html)).

I also handled Axios errors, and added a retry if a masked variable fails to be inserted due to [GitLab's requirements](https://docs.gitlab.com/ee/ci/variables/#mask-a-cicd-variable).

I also had a few building issues that I fixed (eg `npm link` is removed in NPM 9+, and JS files needed to be executable in `bin`).